### PR TITLE
Fixing the table header gap

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -29,7 +29,7 @@
 
 thead {
     position: sticky;
-    top: -1px; /* Don't forget this, required for the stickiness */
+    top: -6px; /* Don't forget this, required for the stickiness */
     background: white;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Fixing the table header gap by adding -5 pixels to the top of the table header thead